### PR TITLE
Level down the requirement about the existence of custom guidelines (from MUST to SHOULD)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ order to discern among them, the [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt
 convention is used throughout the document, thus adding adequate information
 about the criticality of each requirement.
 
+_A citable version of this manuscript is available at http://hdl.handle.net/10261/160086_
+
 ## Open Collaboration
 
 The current baseline has been elaborated and extended based on the first-hand

--- a/content/06.quality_criteria.md
+++ b/content/06.quality_criteria.md
@@ -65,7 +65,7 @@ programming language being used.
 1. Each individual software product MUST comply with a de-facto code style
    standard for althe programming languages used in the codebase.
    i. Compliance with multiple standards MAY exist.
-2. Custom code style guidelines MUST be avoided, only considered in the
+2. Custom code style guidelines SHOULD be avoided, only considered in the
    hypothetical event of programming languages without existing community style
    standards.
     i. Custom styles MUST be documented by defining each convention and its


### PR DESCRIPTION
__IMPORTANT: This project requires an associated issue before creating the pull request.__
 * _Be sure to review our [contribution guidelines](https://github.com/indigo-dc/sqa-baseline/blob/master/CONTRIBUTING.md)_
 * _Check if your contribution is already addressed in the list of [open issues](https://github.com/indigo-dc/sqa-baseline/issues). If not, please [create the issue](https://github.com/indigo-dc/sqa-baseline/issues/new/choose) before opening the pull request_

### Description of the contribution
Use SHOULD instead of MUST when referring to the fact of __avoiding__ the usage of custom guidelines. Otherwise the two subsequent requirements must be removed since they apply to  custom guidelines

### Related Issue/s
resolves #11 