### PR TITLE
When using multiple style standards, they should be complementary

### DIFF
--- a/content/06.quality_criteria.md
+++ b/content/06.quality_criteria.md
@@ -64,7 +64,7 @@ programming language being used.
 
 1. Each individual software product MUST comply with a de-facto code style
    standard for althe programming languages used in the codebase.
-   i. Compliance with multiple standards MAY exist.
+   i. Compliance with multiple complementary standards MAY exist.
 2. Custom code style guidelines SHOULD be avoided, only considered in the
    hypothetical event of programming languages without existing community style
    standards.


### PR DESCRIPTION
__IMPORTANT: This project requires an associated issue before creating the pull request.__
 * _Be sure to review our [contribution guidelines](https://github.com/indigo-dc/sqa-baseline/blob/master/CONTRIBUTING.md)_
 * _Check if your contribution is already addressed in the list of [open issues](https://github.com/indigo-dc/sqa-baseline/issues). If not, please [create the issue](https://github.com/indigo-dc/sqa-baseline/issues/new/choose) before opening the pull request_

### Description of the contribution
The baseline already considers the fact of using multiple standards for programming style, but it does not explicitly say that they should be 'complementary'.

### Related Issue/s
<!--- Please link to the issue here. If the pull request fixes any related issue, be sure to use the appropriate keyword, such as 'resolves #4'. See https://help.github.com/en/articles/closing-issues-using-keywords -->
fixes #10 
